### PR TITLE
Allow newer version of consul-php-sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sensiolabs/consul-php-sdk": ">=2.1 <3.0",
-        "launchdarkly/server-sdk": "^4"
+        "launchdarkly/server-sdk": "^4",
+        "sensiolabs/consul-php-sdk": "^2.1||^3.0||^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
Adds support for the latest versions of the consul-php-sdk.

The newest version does not include the consul binary in the package. I tried to see if there was anything that prevented v3 or v4 from being used, and all tests passed. Was there something that prevented using anything above v2?