### PR TITLE
bump Consul client dependency to 4.x

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -8,6 +8,10 @@ jobs:
   - template:
       name: php
 
+branches:
+  - name: main
+  - name: 1.x
+
 documentation:
   gitHubPages: true
   title: LaunchDarkly PHP SDK Consul integration

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This library provides a [Consul](https://www.consul.io/)-backed data source for 
 
 The minimum version of the LaunchDarkly PHP SDK for use with this library is 4.0.0. In earlier versions of the SDK, the Consul integration was bundled in the main SDK package.
 
+This version of the package uses version 4.x of the `consul-php-sdk` client. If your application needs to use an earlier version of `consul-php-sdk`, use a 1.x version of `launchdarkly/server-sdk-consul`.
+
 The minimum PHP version is 7.3.
 
 For more information, see [our SDK documentation](https://docs.launchdarkly.com/sdk/features/storing-data).

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sensiolabs/consul-php-sdk": ">=2.1 <3.0",
+        "sensiolabs/consul-php-sdk": "^4",
         "launchdarkly/server-sdk": "^4"
     },
     "require-dev": {


### PR DESCRIPTION
This will be for a 2.0.0 release of `php-server-sdk-consul`. See: https://github.com/launchdarkly/php-server-sdk-consul/pull/10

Note that we cannot extend the dependency constraint to include 5.x, because the 5.x release of the Consul client has a different package name and a different namespace. So we will need to create yet another version to support that.