### PR TITLE
bump Consul client dependency to 5.x in new major version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ workflows:
   workflow:
     jobs:
       - linux-test:
-          name: PHP 7.3
-          docker-image: cimg/php:7.3
-      - linux-test:
           name: PHP 7.4
           docker-image: cimg/php:7.4
       - linux-test:

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -12,6 +12,7 @@ jobs:
 
 branches:
   - name: main
+  - name: 2.x
   - name: 1.x
 
 documentation:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![CircleCI](https://circleci.com/gh/launchdarkly/php-server-sdk-consul.svg?style=svg)](https://circleci.com/gh/launchdarkly/php-server-sdk-consul)
 
-This library provides a [Consul](https://www.consul.io/)-backed data source for the [LaunchDarkly PHP SDK](https://github.com/launchdarkly/php-server-sdk), replacing the default behavior of querying the LaunchDarkly service endpoints. The underlying Consul client implementation is the [`sensiolabs/consul-php-sdk`](https://github.com/FriendsOfPHP/consul-php-sdk) package.
+This library provides a [Consul](https://www.consul.io/)-backed data source for the [LaunchDarkly PHP SDK](https://github.com/launchdarkly/php-server-sdk), replacing the default behavior of querying the LaunchDarkly service endpoints. The underlying Consul client implementation is the [`friendsofphp/consul-php-sdk`](https://github.com/FriendsOfPHP/consul-php-sdk) package.
 
 The minimum version of the LaunchDarkly PHP SDK for use with this library is 4.0.0. In earlier versions of the SDK, the Consul integration was bundled in the main SDK package.
 
-This version of the package uses version 4.x of the `consul-php-sdk` client. If your application needs to use an earlier version of `consul-php-sdk`, use a 1.x version of `launchdarkly/server-sdk-consul`.
+This version of the package uses version 5.x of the `consul-php-sdk` client. If your application needs to use an earlier version of `consul-php-sdk`, use `launchdarkly/server-sdk-consul` 1.x (for version 2.x of `consul-php-sdk`) or `launchdarkly/server-sdk-consul` 2.x (for version 4.x of `consul-php-sdk`).
 
 The minimum PHP version is 7.3.
 
@@ -22,7 +22,7 @@ This assumes that you have already installed the LaunchDarkly PHP SDK in your pr
 php composer.phar install launchdarkly/server-sdk-consul --save
 ```
 
-If your project does not already have a dependency on `sensiolabs/consul-php-sdk`, that package will be loaded automatically as a dependency of `launchdarkly/server-sdk-consul`.
+If your project does not already have a dependency on `friendsofphp/consul-php-sdk`, that package will be loaded automatically as a dependency of `launchdarkly/server-sdk-consul`.
 
 3. In your SDK configuration code, configure the Consul integration:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The minimum version of the LaunchDarkly PHP SDK for use with this library is 4.0
 
 This version of the package uses version 5.x of the `consul-php-sdk` client. If your application needs to use an earlier version of `consul-php-sdk`, use `launchdarkly/server-sdk-consul` 1.x (for version 2.x of `consul-php-sdk`) or `launchdarkly/server-sdk-consul` 2.x (for version 4.x of `consul-php-sdk`).
 
-The minimum PHP version is 7.3.
+The minimum PHP version is 7.4.
 
 For more information, see [our SDK documentation](https://docs.launchdarkly.com/sdk/features/storing-data).
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "friendsofphp/consul-php-sdk": "^5",
         "launchdarkly/server-sdk": "^4"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sensiolabs/consul-php-sdk": "^4",
+        "friendsofphp/consul-php-sdk": "^5",
         "launchdarkly/server-sdk": "^4"
     },
     "require-dev": {

--- a/src/LaunchDarkly/Impl/Integrations/ConsulFeatureRequester.php
+++ b/src/LaunchDarkly/Impl/Integrations/ConsulFeatureRequester.php
@@ -2,8 +2,8 @@
 namespace LaunchDarkly\Impl\Integrations;
 
 use LaunchDarkly\Impl\Integrations\FeatureRequesterBase;
-use SensioLabs\Consul\Exception\ClientException;
-use SensioLabs\Consul\ServiceFactory;
+use Consul\Exception\ClientException;
+use Consul\Services\KV;
 
 /**
  * @internal
@@ -23,8 +23,7 @@ class ConsulFeatureRequester extends FeatureRequesterBase
         if (isset($options['consul_uri'])) {
             $consulOpts['base_uri'] = $options['consul_uri'];
         }
-        $sf = new ServiceFactory($consulOpts);
-        $this->_kvClient = $sf->get('kv');
+        $this->_kvClient = new KV();
 
         $prefix = $options['consul_prefix'] ?? null;
         if ($prefix === null || $prefix === '') {

--- a/tests/ConsulFeatureRequesterTest.php
+++ b/tests/ConsulFeatureRequesterTest.php
@@ -5,8 +5,8 @@ namespace LaunchDarkly\Impl\Integrations\Tests;
 use LaunchDarkly\FeatureRequester;
 use LaunchDarkly\Integrations\Consul;
 use LaunchDarkly\SharedTest\DatabaseFeatureRequesterTestBase;
-use SensioLabs\Consul\Exception\ClientException;
-use SensioLabs\Consul\ServiceFactory;
+use Consul\Exception\ClientException;
+use Consul\Services\KV;
 
 class ConsulFeatureRequesterTest extends DatabaseFeatureRequesterTestBase
 {
@@ -14,8 +14,7 @@ class ConsulFeatureRequesterTest extends DatabaseFeatureRequesterTestBase
 
     public static function setUpBeforeClass(): void
     {
-        $sf = new ServiceFactory();
-        self::$kvClient = $sf->get('kv');
+        self::$kvClient = new KV();
     }
 
     private static function realPrefix(?string $prefix): string


### PR DESCRIPTION
This will be for a 3.0.0 release of our integration package. The package name, namespace, and API all changed in the 5.x release of the client.