### PR TITLE
relax SDK dependency to allow v5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LaunchDarkly Server-Side SDK for PHP - Consul integration
 
 [![CircleCI](https://circleci.com/gh/launchdarkly/php-server-sdk-consul.svg?style=svg)](https://circleci.com/gh/launchdarkly/php-server-sdk-consul)
+[![Packagist](https://img.shields.io/packagist/v/launchdarkly/server-sdk-consul.svg?style=flat-square)](https://packagist.org/packages/launchdarkly/server-sdk-consul)
+[![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=API+reference&color=00add8)](https://launchdarkly.github.io/php-server-sdk-consul)
 
 This library provides a [Consul](https://www.consul.io/)-backed data source for the [LaunchDarkly PHP SDK](https://github.com/launchdarkly/php-server-sdk), replacing the default behavior of querying the LaunchDarkly service endpoints. The underlying Consul client implementation is the [`friendsofphp/consul-php-sdk`](https://github.com/FriendsOfPHP/consul-php-sdk) package.
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.4",
         "friendsofphp/consul-php-sdk": "^5",
-        "launchdarkly/server-sdk": "^4"
+        "launchdarkly/server-sdk": ">=4.0.0 <6.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",


### PR DESCRIPTION
There aren't any relevant internal API differences so the same package will work with both 4.x and 5.0.